### PR TITLE
Fix TypeError: 'null is not an object' in res.status Evaluation

### DIFF
--- a/lib/bao.ts
+++ b/lib/bao.ts
@@ -159,7 +159,7 @@ export class Bao {
       async fetch(req: Request, server: Server) {
         let ctx = new Context(req, server);
         const res = await router.handle(ctx);
-        return res.status === 404 ? notFoundHandler(ctx) : res;
+        return [404, null].some((x) => x == res?.status) ? notFoundHandler(ctx) : res;
       },
       error(error: Error) {
         return errorHandler(error);


### PR DESCRIPTION
Fixes: null is not an object (evaluating 'res.status')
```cs
129 |                 message: (ws, msg) => router.handleWebSocket(ws).message(msg),
130 |             },
131 |             async fetch(req, server) {
132 |                 let ctx = new Context(req, server);
133 |                 const res = await router.handle(ctx);
134 |                 return res.status === 404 ? notFoundHandler(ctx) : res;
                             ^
TypeError: null is not an object (evaluating 'res.status')
```